### PR TITLE
Fix wrong stdin queue order

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.1

--- a/src/main/scala/eu/monniot/process/Process.scala
+++ b/src/main/scala/eu/monniot/process/Process.scala
@@ -111,7 +111,7 @@ object Process {
         // Ensure we consume the entire buffer in case it's not used.
         buffer.position(buffer.limit)
 
-        dispatcher.unsafeRunAndForget(q.offer(Some(bv)))
+        dispatcher.unsafeRunSync(q.offer(Some(bv)))
       }
 
       override def onStdout(buffer: ByteBuffer, closed: Boolean): Unit =


### PR DESCRIPTION
Because of unsafeRunAndForget was used, order of bytes from stdin and order of bytes in stdinQ: Queue[F, ByteVector] could be different. It doesn't look right, so I switched to unsafeRunSync. 
And up sbt version to the latest. 